### PR TITLE
Distinguish 500 Error codes from Vindicia vs Network Errors

### DIFF
--- a/lib/vindicia/version.rb
+++ b/lib/vindicia/version.rb
@@ -1,3 +1,3 @@
 module Vindicia
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/vindicia/model_test.rb
+++ b/test/vindicia/model_test.rb
@@ -49,13 +49,23 @@ class Vindicia::ModelTest < Test::Unit::TestCase
     end
   end
 
-  def test_should_catch_exceptions_thrown_underneath_savon
-    Vindicia::AutoBill.client.expects(:request).once.raises(Timeout::Error)
+  def test_should_catch_500_exceptions_thrown_underneath_savon
+    Vindicia::AutoBill.client.expects(:request).once.raises(StandardError)
 
     resp = Vindicia::AutoBill.update({})
 
     assert_not_nil resp
     assert resp.to_hash
     assert_equal '500', resp[:update_response][:return][:return_code]
+  end
+
+  def test_should_catch_503_exceptions_thrown_underneath_savon
+    Vindicia::AutoBill.client.expects(:request).once.raises(Timeout::Error)
+
+    resp = Vindicia::AutoBill.update({})
+
+    assert_not_nil resp
+    assert resp.to_hash
+    assert_equal '503', resp[:update_response][:return][:return_code]
   end
 end

--- a/vindicia-api.gemspec
+++ b/vindicia-api.gemspec
@@ -3,22 +3,23 @@ $:.push File.expand_path("../lib", __FILE__)
 require 'vindicia/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "vindicia-api"
+  gem.name          = 'vindicia-api'
   gem.version       = Vindicia::VERSION
-  gem.authors       = ["Tom Quackenbush", "Victor Garro"]
-  gem.email         = ["tquackenbush@agoragames.com", "vgarro@verticalresponse.com"]
-  gem.homepage      = "https://github.com/agoragames/vindicia-api"
+  gem.authors       = ['Tom Quackenbush', 'Victor Garro']
+  gem.email         = ['tquackenbush@agoragames.com', 'vgarro@verticalresponse.com']
+  gem.homepage      = 'https://github.com/agoragames/vindicia-api'
   gem.summary       = %q{A wrapper for creating queries to the Vindicia CashBox API}
-  gem.description   = %q{A wrapper for creating queries to the Vindicia CashBox API}
+  gem.description   = %q{Provides a Singleton series of classes to communicate with Vindicia's Cashbox API}
+  gem.license       = 'Copyright (c) 2011-2013 Agora Games'
 
-  gem.rubyforge_project = "vindicia-api"
+  gem.rubyforge_project = 'vindicia-api'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
-  gem.add_dependency('savon', '~> 1.2.0')
+  gem.add_dependency('savon', '= 1.2.0')
   gem.add_dependency('activesupport')
 
   gem.add_development_dependency('rake')


### PR DESCRIPTION
- Extracted Savon::HTTP::Error and  Timeout::Error to be distinguish
- Refactor exception handling method to deal with required errors

[Fixes #56018944]
